### PR TITLE
[KAN-07] Setup Flask Frontend Environment

### DIFF
--- a/Flask_Frontend/Templates/query.html
+++ b/Flask_Frontend/Templates/query.html
@@ -1,0 +1,7 @@
+<!-- this is the html to display notams -->
+<!DOCTYPE html>
+<html>
+    This page is not yet implemented.
+    {{ DepartureAirport }}
+    {{ ArrivalAirport }}
+</html>

--- a/Flask_Frontend/Templates/user_input.html
+++ b/Flask_Frontend/Templates/user_input.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+    <form action="/query" method = "POST">
+        <p>Departure Airport <input type = "text" name = "DepartureAirport" /></p>
+        <p>Arrival Airport <input type = "text" name = "ArrivalAirport" /></p>
+        <p><input type = "submit" value = "Search" /></p>
+    </form>
+</html>

--- a/Flask_Frontend/app.py
+++ b/Flask_Frontend/app.py
@@ -1,0 +1,20 @@
+from flask import Flask, request
+from flask import render_template
+app = Flask(__name__)
+#import notamFetch
+
+# Home displays the form for user input
+@app.route("/")
+def home():
+    return render_template(
+        "user_input.html",
+    )
+
+# /query displays the notams
+@app.route('/query/', methods = ['POST', 'GET'])
+def query():
+    if request.method == 'POST':
+        #notamFetch.getNotams(depAP, arrAP)
+        return render_template('query.html', 
+                DepartureAirport = request.form['DepartureAirport'], 
+                ArrivalAirport = request.form['ArrivalAirport'])

--- a/Flask_Frontend/requirements.txt
+++ b/Flask_Frontend/requirements.txt
@@ -1,0 +1,13 @@
+beautifulsoup4==4.12.2
+blinker==1.7.0
+bs4==0.0.1
+click==8.1.7
+colorama==0.4.6
+Flask==3.0.2
+importlib-metadata==7.0.1
+itsdangerous==2.1.2
+Jinja2==3.1.3
+MarkupSafe==2.1.5
+soupsieve==2.5
+Werkzeug==3.0.1
+zipp==3.17.0

--- a/README.md
+++ b/README.md
@@ -1,11 +1,22 @@
 # NOTAM SORT
 Notam Sort is a webpage that takes the input from the user for a departure and arrival airport and using the FAA api retrieve the NOTAMS relevant to the projected path.
-
 ## Requirements 
 Python 3.11.3
-
 ## Installing Dependencies
+If you import a new module into your script, you will need to run the following command so that everyone else can easily install the new dependencies:
 ```
 pip freeze > requirements.txt
-pip install requirements.txt
 ```
+If python tells you it can't find certain modules, run the below script to install them:
+```
+pip install -r requirements.txt
+```
+## Running Flask
+1. Make sure to run ```pip install -r requirements.txt``` to install everything need for Flask.
+2. In the directory containing `app.py`, run the following command in your python environment: ```python -m flask run``` You'll see something like this: 
+> (.venv) C:\\...\\Flask_Frontend>python -m flask run
+>  * Debug mode: off
+> WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
+>  * Running on http://127.0.0.1:5000
+> Press CTRL+C to quit
+4. `Ctrl-click` the URL http://127.0.0.1:5000 to open the Flask webpage.


### PR DESCRIPTION
Squashed and rebased branch.  Commit messages below:

- Added `gitignore` for files pertaining to flask and python
- `requirements.txt` has all dependences needed; your IDE may automatically ask you if you want to install these dependencies, if it doesn't just run `pip install -r requirements.txt` in the `\Flask_Frontend` directory.
- `app.py` is the only script file
- `/Templates` contains all the html files for each page
- There is a page for user input, and a second page to display results after clicking Search

[KAN-07] Query page still not implemented, it's just a dummy page with the values from the form text boxes (the two airports).

[KAN-07] Removed duplicate .gitignore, added README instructions for Flask

.gitignore is now in the root, so my .gitignore is now uneccessary. Updated the README:
1. 'Installing Dependencies' now has clearer instructions for when to run 'pip freeze' and 'pip install'
2. Added instructions on how to run the Flask app.