### PR TITLE
[KAN-44] notamFetch now returns a list of Notam objects

### DIFF
--- a/Notam.py
+++ b/Notam.py
@@ -1,7 +1,39 @@
 class Notam:
-    effective_start = ""
-    effective_end = ""
-    text = ""
-    type = ""
-    location = ""
-    priority = 0 #used for sorting
+# Property names as they appear in the FAA API for an easier way to 
+# retreive specific properties without having to reference the FAA 
+# API for spelling/casing conventions.
+    EFFECTIVE_START = "effectiveStart"
+    EFFECTIVE_END = "effectiveEnd"
+    TEXT = "text"
+    TYPE = "type"
+    LOCATION = "location"
+    NUMBER = "number"
+    
+    def __init__(self, raw_notam_data):
+        """
+        Parameters
+        ----------
+        raw_notam_data : str
+            The raw NOTAM response from the FAA API.
+        """
+        notam_properties = raw_notam_data.get("properties").get("coreNOTAMData").get("notam")
+
+        self.effective_start = notam_properties.get(Notam.EFFECTIVE_START)
+        self.effective_end = notam_properties.get(Notam.EFFECTIVE_END)
+        self.text = notam_properties.get(Notam.TEXT)
+        self.type = notam_properties.get(Notam.TYPE)
+        self.location = notam_properties.get(Notam.LOCATION)
+        self.number = notam_properties.get(Notam.NUMBER)
+            
+    def __str__(self):
+        """Returns a string representing the notam object in the form
+            [number] variable : value
+
+        Can easily print a list of notams with print(*notam_list).
+        """
+
+        notam_vars = vars(self)
+        output=""        
+        for item in notam_vars:
+            output += f"[{self.number}] {item}: {notam_vars[item]}\n"
+        return output

--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 from flask import Flask, request
 from flask import render_template
+import notamFetch
 app = Flask(__name__)
 #import notamFetch
 
@@ -14,7 +15,8 @@ def home():
 @app.route('/query/', methods = ['POST', 'GET'])
 def query():
     if request.method == 'POST':
-        #notamFetch.getNotams(depAP, arrAP)
+        # print(*notamFetch.get_all_notams(request.form['DepartureAirport'], request.form['ArrivalAirport']), sep='')
+
         return render_template('query.html', 
                 DepartureAirport = request.form['DepartureAirport'], 
                 ArrivalAirport = request.form['ArrivalAirport'])

--- a/notamFetch.py
+++ b/notamFetch.py
@@ -4,7 +4,7 @@ import os
 import sys
 from geopy.geocoders import Nominatim
 from dotenv import load_dotenv
-import Notam
+from Notam import Notam
 
 
 # Querying the FAA NOTAM API requires authorization. There are two components
@@ -84,10 +84,10 @@ def send_api_request(request_latitude_longitude : dict) -> list:
 
     # Get all of the notams and place them inside of notam list.
     for notam in returned_notam_list:
-        
-        current_notam_properties = notam.get("properties").get("coreNOTAMData").get("notam")
-        current_notam_text = current_notam_properties.get("text")
-        notam_list.append(current_notam_text)
+        # Create a Notam object and append to the notam list. The Notam
+        # class contains constants to get specific properties from the 
+        # FAA api easily.
+        notam_list.append(Notam(notam))
     
     print(f"Found {len(notam_list)} notams at {request_latitude_longitude}")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+Babel==2.14.0
 beautifulsoup4==4.12.2
 blinker==1.7.0
 bs4==0.0.1
@@ -5,7 +6,9 @@ certifi==2024.2.2
 charset-normalizer==3.3.2
 click==8.1.7
 colorama==0.4.6
-Flask==3.0.2
+Flask==2.3.3
+flask-babel==4.0.0
+Flask-Table==0.5.0
 geographiclib==2.0
 geopy==2.4.1
 idna==3.6
@@ -14,6 +17,7 @@ itsdangerous==2.1.2
 Jinja2==3.1.3
 MarkupSafe==2.1.5
 python-dotenv==1.0.1
+pytz==2024.1
 requests==2.31.0
 soupsieve==2.5
 urllib3==2.2.1


### PR DESCRIPTION
To make object creation easier, Notam.py now has:
1. Two `__init__`, one with the priority variable and one without
2. `__str__` for printing notams in an easy-to-read format
3. A list of constants referring to the property names in the faa api. Now we can use `.get(Notam.EFFECTIVE_START)` in lieu of `.get('effectiveStart')`

In notamFetch.py:
1. send_api_request now returns list of notam objects, rather than a list of 'text' strings.