### PR TITLE
[KAN-40] Add error handling for common http response codes from FAA API

### DIFF
--- a/tests/api_http_errors.py
+++ b/tests/api_http_errors.py
@@ -1,0 +1,45 @@
+import unittest
+import notamFetch
+
+# Run unit tests by running `python3 -m unittest tests/api_http_errors.py`
+
+# Making a note here that it's not really a great idea to have unit tests that
+# test a live API. Not only could it be swingy and give false positives when
+# the API is down, but it's additional load on FAA servers that's likely
+# unwanted. The better way would be to mock up requests.get() to return HTTP
+# codes and mocked responses.
+
+class TestHttpResponseStatusCodes( unittest.TestCase ):
+
+    COORDINATES = { notamFetch.LAT_KEY: 35, notamFetch.LONG_KEY: -95 }
+
+    def test_authorized( self ):
+        try:
+            notamFetch.send_api_request( self.COORDINATES )
+        except Exception as err:
+            self.fail( "An exception was raised when it shouldn't have" )
+        pass
+
+    def test_unauthorized( self ):
+        good_credentials = notamFetch.credentials
+        with self.assertRaises( RuntimeError ) as context:
+            notamFetch.credentials = { "client_id": "bad_id", "client_secret": "bad_secret" }
+            notamFetch.send_api_request( self.COORDINATES )
+
+        self.assertTrue( "HTTP 401" in str(context.exception), f"Expected a 401 exception but got {str(context.exception)} instead" )
+        notamFetch.credentials = good_credentials
+
+    def test_bad_request( self ):
+        with self.assertRaises( RuntimeError ) as context:
+            notamFetch.send_api_request( self.COORDINATES, additional_params={"pageSize":999999} )
+
+        self.assertTrue( "Received error message" in str(context.exception), f"Expected an error message but got {str(context.exception)} instead" )
+
+    def test_not_found( self ):
+        good_url = notamFetch.faa_api
+        with self.assertRaises( RuntimeError ) as context:
+            notamFetch.faa_api = f"{good_url}_OBVIOUSLY_BAD_URL"
+            notamFetch.send_api_request( self.COORDINATES )
+
+        self.assertTrue( "HTTP 404" in str(context.exception), f"Expected a 404 exception but got {str(context.exception)} instead" )
+        notamFetch.faa_api = good_url


### PR DESCRIPTION
This change includes a `tests/` folder for using the `unitttest` module. Run unit tests by executing this command from the root folder:

python3 -m unittest tests/api_http_errors.py

Note this change also includes a slight alteration to `send_api_request()`. The caller to this function may now specify an optional `additional_param` dict, to allow for the injection of specific HTTP parameters to the FAA API.  Any params with the same key will overwrite any existing params.