### PR TITLE
[KAN-48] Implemented method to validate airport codes

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,6 +22,9 @@ def query():
     /query as a NotamTable.
     """
     if request.method == 'POST':
+        departure_airport = request.form['DepartureAirport']
+        arrival_airport = request.form['ArrivalAirport']
+
         # call backend to retrieve list of notams
         all_notams = notamFetch.get_all_notams(
             departure_airport = departure_airport, 


### PR DESCRIPTION
- I figured out how to use Nominatim to validate US airport codes
- Frontend now has the function `valid_US_airport_code`; once displaying error messages to the user through Flask is implemented, `valid_US_airport_code` will be called before calling `notamFetch`
- I also made `test_validation_with_input` just to test the validation code with the current Flask form; it will vanish once displaying error messages are implemented.