### PR TITLE
[KAN-51] fixed a couple bugs with expecting floats instead of ints and list concatenation

### DIFF
--- a/NavigationTools.py
+++ b/NavigationTools.py
@@ -54,6 +54,8 @@ class PointObject :
                 longitude = location_geocode.longitude
                 return cls(latitude, longitude)
 
+    def __str__(self) :
+        return f"Latitude: {self.latitude}, Longitude: {self.longitude}"
 
 
 def get_distance(point_one: PointObject, point_two: PointObject) :

--- a/NavigationTools.py
+++ b/NavigationTools.py
@@ -128,7 +128,7 @@ def get_bearing(point_one: PointObject, point_two: PointObject) -> float :
     return bearing
 
 
-def get_next_point_geopy(point: PointObject, bearing: float, distance: float) -> PointObject :
+def get_next_point_geopy(point: PointObject, bearing: float, distance: float| int) -> PointObject :
     """
     point: point from wich we start measuring distance
     distance: target distance from the start in nautical miles
@@ -141,8 +141,8 @@ def get_next_point_geopy(point: PointObject, bearing: float, distance: float) ->
         error_log.append(f"Error: point_one is of the wrong type, expected PointObject and got {type(point)}")
     if not(isinstance(bearing, float)) :
         error_log.append(f"Error: bearing is of the wrong type, expected float and got {type(bearing)}")
-    if not(isinstance(distance, float)) :
-        error_log.append(f"Error: distance is of the wrong type, expected float and got {type(distance)}")
+    if not(isinstance(distance, (float, int))) :
+        error_log.append(f"Error: distance is of the wrong type, expected float or int and got {type(distance)}")
 
     if error_log :
         error_message = "\n".join(error_log)
@@ -159,7 +159,7 @@ def get_next_point_geopy(point: PointObject, bearing: float, distance: float) ->
 # results confirmed by https://www.fcc.gov/media/radio/find-terminal-coordinates
 # both methods are off in the latitude by ~0.001 of the FCC calculator in different directions
 # we currently only use the geopy implementation to find the next point not this one
-def get_next_point_manual(point: PointObject, bearing: float, distance: float) -> PointObject :
+def get_next_point_manual(point: PointObject, bearing: float, distance: float | int) -> PointObject :
     """
     point: point from wich we start measuring distance
     bearing: heading in degrees
@@ -172,11 +172,8 @@ def get_next_point_manual(point: PointObject, bearing: float, distance: float) -
         error_log.append(f"Error: point_one is of the wrong type, expected PointObject and got {type(point)}")
     if not(isinstance(bearing, float)) :
         error_log.append(f"Error: bearing is of the wrong type, expected float and got {type(bearing)}")
-    if not(isinstance(distance, float)) :
-        if (isinstance(distance, int)) :
-            distance = float(distance)
-        else :
-            error_log.append(f"Error: distance is of the wrong type, expected float or int and got {type(distance)}")
+    if not(isinstance(distance, (float, int))) :
+        error_log.append(f"Error: distance is of the wrong type, expected float or int and got {type(distance)}")
 
     if error_log :
         error_message = "\n".join(error_log)

--- a/NavigationTools.py
+++ b/NavigationTools.py
@@ -19,10 +19,10 @@ class PointObject :
 
     def __init__(self, latitude = None, longitude = None) :
         error_log = []
-        if not(isinstance(latitude, float)) :
-            error_log.append(f"Error: latitude is of the wrong type, expected float and got {type(latitude)}")
-        if not(isinstance(longitude, float)) :
-            error_log.append(f"Error: longitude is of the wrong type, expected float and got {type(longitude)}")
+        if not(isinstance(latitude, (float, int))) :
+            error_log.append(f"Error: latitude is of the wrong type, expected float or int and got {type(latitude)}")
+        if not(isinstance(longitude, (float, int))) :
+            error_log.append(f"Error: longitude is of the wrong type, expected float or int and got {type(longitude)}")
             
         if abs(latitude) > 90 :
             error_log.append(f"Error: Incorrect value for latitude, must be between -90 and 90")

--- a/NavigationTools.py
+++ b/NavigationTools.py
@@ -173,7 +173,10 @@ def get_next_point_manual(point: PointObject, bearing: float, distance: float) -
     if not(isinstance(bearing, float)) :
         error_log.append(f"Error: bearing is of the wrong type, expected float and got {type(bearing)}")
     if not(isinstance(distance, float)) :
-        error_log.append(f"Error: distance is of the wrong type, expected float and got {type(distance)}")
+        if (isinstance(distance, int)) :
+            distance = float(distance)
+        else :
+            error_log.append(f"Error: distance is of the wrong type, expected float or int and got {type(distance)}")
 
     if error_log :
         error_message = "\n".join(error_log)

--- a/app.py
+++ b/app.py
@@ -15,7 +15,7 @@ def home():
 @app.route('/query/', methods = ['POST', 'GET'])
 def query():
     if request.method == 'POST':
-        # print(*notamFetch.get_all_notams(request.form['DepartureAirport'], request.form['ArrivalAirport']), sep='')
+        print(notamFetch.get_all_notams(request.form['DepartureAirport'], request.form['ArrivalAirport']), sep='')
 
         return render_template('query.html', 
                 DepartureAirport = request.form['DepartureAirport'], 

--- a/notamFetch.py
+++ b/notamFetch.py
@@ -172,7 +172,7 @@ def get_notams_between(point_one: PointObject, point_two: PointObject, spacing: 
     current_point = point_one
     for i in range(0, int((total_distance)-spacing), int(spacing)) :
         next_point = get_next_point_manual(current_point, bearing, spacing)
-        middle_notams.append(get_notams_at(next_point))
+        middle_notams += get_notams_at(next_point)
         current_point = next_point
     return middle_notams
 

--- a/notamFetch.py
+++ b/notamFetch.py
@@ -142,7 +142,7 @@ def get_all_notams(departure_airport : str, arrival_airport : str) -> list:
     return sort_list.sort(full_notam_list)
 
 
-def get_notams_between(point_one: PointObject, point_two: PointObject, spacing: int) -> list :
+def get_notams_between(point_one: PointObject, point_two: PointObject, spacing: float | int) -> list :
     """
     point_one: starting point
     point_two: ending point
@@ -155,8 +155,8 @@ def get_notams_between(point_one: PointObject, point_two: PointObject, spacing: 
         error_log.append(f"Error: point_one is of the wrong type, expected PointObject and got {type(point_one)}")
     if not(isinstance(point_two, PointObject)) :
         error_log.append(f"Error: point_two is of the wrong type, expected PointObject and got {type(point_one)}")
-    if not(isinstance(spacing, int)) :
-        error_log.append(f"Error: spacing is of the wrong type, expected int and got {type(spacing)}")
+    if not(isinstance(spacing, (float, int))) :
+        error_log.append(f"Error: spacing is of the wrong type, expected float or int and got {type(spacing)}")
     if error_log :
         error_message = "\n".join(error_log)
         raise ValueError(error_message)
@@ -170,7 +170,7 @@ def get_notams_between(point_one: PointObject, point_two: PointObject, spacing: 
     # we could divide the distance by some max number of api calls instead
     middle_notams = []
     current_point = point_one
-    for i in range(0, (int(total_distance)-spacing), spacing) :
+    for i in range(0, int((total_distance)-spacing), int(spacing)) :
         next_point = get_next_point_manual(current_point, bearing, spacing)
         middle_notams.append(get_notams_at(next_point))
         current_point = next_point

--- a/notamFetch.py
+++ b/notamFetch.py
@@ -170,7 +170,7 @@ def get_notams_between(point_one: PointObject, point_two: PointObject, spacing: 
     # we could divide the distance by some max number of api calls instead
     middle_notams = []
     current_point = point_one
-    for i in range(0, (total_distance-spacing), spacing) :
+    for i in range(0, (int(total_distance)-spacing), spacing) :
         next_point = get_next_point_manual(current_point, bearing, spacing)
         middle_notams.append(get_notams_at(next_point))
         current_point = next_point

--- a/notamFetch.py
+++ b/notamFetch.py
@@ -48,7 +48,7 @@ credentials = {
 }
 
 
-def get_notams_at(request_location : PointObject) -> list:
+def get_notams_at(request_location : PointObject, additional_params = {}) -> list:
     """ 
     This function takes the notam request, requests the api for the notams, and then returns the output.
     request_latitude_longitude expects to be a PointObject object containing the parameters 'latitude' and 'longitude' and contain type float values
@@ -142,7 +142,7 @@ def get_all_notams(departure_airport : str, arrival_airport : str) -> list:
     return sort_list.sort(full_notam_list)
 
 
-def get_notams_between(point_one: PointObject, point_two: PointObject, spacing: float) -> list :
+def get_notams_between(point_one: PointObject, point_two: PointObject, spacing: int) -> list :
     """
     point_one: starting point
     point_two: ending point
@@ -155,8 +155,8 @@ def get_notams_between(point_one: PointObject, point_two: PointObject, spacing: 
         error_log.append(f"Error: point_one is of the wrong type, expected PointObject and got {type(point_one)}")
     if not(isinstance(point_two, PointObject)) :
         error_log.append(f"Error: point_two is of the wrong type, expected PointObject and got {type(point_one)}")
-    if not(isinstance(spacing, float)) :
-        error_log.append(f"Error: spacing is of the wrong type, expected float and got {type(spacing)}")
+    if not(isinstance(spacing, int)) :
+        error_log.append(f"Error: spacing is of the wrong type, expected int and got {type(spacing)}")
     if error_log :
         error_message = "\n".join(error_log)
         raise ValueError(error_message)

--- a/tests/api_http_errors.py
+++ b/tests/api_http_errors.py
@@ -12,7 +12,7 @@ from NavigationTools import PointObject
 
 class TestHttpResponseStatusCodes( unittest.TestCase ):
 
-    COORDINATES = PointObject(35.0, -95.0)
+    COORDINATES = PointObject(35, -95)
 
     def test_authorized( self ):
         try:

--- a/tests/api_http_errors.py
+++ b/tests/api_http_errors.py
@@ -12,7 +12,7 @@ from NavigationTools import PointObject
 
 class TestHttpResponseStatusCodes( unittest.TestCase ):
 
-    COORDINATES = PointObject(35, -95)
+    COORDINATES = PointObject(35.0, -95.0)
 
     def test_authorized( self ):
         try:

--- a/tests/api_http_errors.py
+++ b/tests/api_http_errors.py
@@ -1,5 +1,6 @@
 import unittest
 import notamFetch
+from NavigationTools import PointObject
 
 # Run unit tests by running `python3 -m unittest tests/api_http_errors.py`
 
@@ -11,11 +12,11 @@ import notamFetch
 
 class TestHttpResponseStatusCodes( unittest.TestCase ):
 
-    COORDINATES = { notamFetch.LAT_KEY: 35, notamFetch.LONG_KEY: -95 }
+    COORDINATES = PointObject(35, -95)
 
     def test_authorized( self ):
         try:
-            notamFetch.send_api_request( self.COORDINATES )
+            notamFetch.get_notams_at( self.COORDINATES )
         except Exception as err:
             self.fail( "An exception was raised when it shouldn't have" )
         pass
@@ -24,14 +25,14 @@ class TestHttpResponseStatusCodes( unittest.TestCase ):
         good_credentials = notamFetch.credentials
         with self.assertRaises( RuntimeError ) as context:
             notamFetch.credentials = { "client_id": "bad_id", "client_secret": "bad_secret" }
-            notamFetch.send_api_request( self.COORDINATES )
+            notamFetch.get_notams_at( self.COORDINATES )
 
         self.assertTrue( "HTTP 401" in str(context.exception), f"Expected a 401 exception but got {str(context.exception)} instead" )
         notamFetch.credentials = good_credentials
 
     def test_bad_request( self ):
         with self.assertRaises( RuntimeError ) as context:
-            notamFetch.send_api_request( self.COORDINATES, additional_params={"pageSize":999999} )
+            notamFetch.get_notams_at( self.COORDINATES, additional_params={"pageSize":999999} )
 
         self.assertTrue( "Received error message" in str(context.exception), f"Expected an error message but got {str(context.exception)} instead" )
 
@@ -39,7 +40,7 @@ class TestHttpResponseStatusCodes( unittest.TestCase ):
         good_url = notamFetch.faa_api
         with self.assertRaises( RuntimeError ) as context:
             notamFetch.faa_api = f"{good_url}_OBVIOUSLY_BAD_URL"
-            notamFetch.send_api_request( self.COORDINATES )
+            notamFetch.get_notams_at( self.COORDINATES )
 
         self.assertTrue( "HTTP 404" in str(context.exception), f"Expected a 404 exception but got {str(context.exception)} instead" )
         notamFetch.faa_api = good_url


### PR DESCRIPTION
Our error checking was a bit too strict. Usually the `int`s would have just been cast to a `float` but we were throwing errors. There was also an issue where I was creating a list of lists (Cory called it) instead of a single list.