### PR TITLE
[KAN-26] Multi-threading FAA API calls

### DIFF
--- a/tests/api_http_errors.py
+++ b/tests/api_http_errors.py
@@ -1,5 +1,6 @@
 import unittest
 import notamFetch
+from io import StringIO
 from NavigationTools import PointObject
 
 # Run unit tests by running `python3 -m unittest tests/api_http_errors.py`
@@ -13,10 +14,13 @@ from NavigationTools import PointObject
 class TestHttpResponseStatusCodes( unittest.TestCase ):
 
     COORDINATES = PointObject(35, -95)
+    credentials = notamFetch.load_credentials()
+    message_log = StringIO()
 
     def test_authorized( self ):
         try:
-            notamFetch.get_notams_at( self.COORDINATES )
+            notamFetch.credentials = self.credentials
+            notamFetch.get_notams_at( self.COORDINATES, self.message_log )
         except Exception as err:
             self.fail( "An exception was raised when it shouldn't have" )
         pass
@@ -25,22 +29,24 @@ class TestHttpResponseStatusCodes( unittest.TestCase ):
         good_credentials = notamFetch.credentials
         with self.assertRaises( RuntimeError ) as context:
             notamFetch.credentials = { "client_id": "bad_id", "client_secret": "bad_secret" }
-            notamFetch.get_notams_at( self.COORDINATES )
+            notamFetch.get_notams_at( self.COORDINATES, self.message_log )
 
         self.assertTrue( "HTTP 401" in str(context.exception), f"Expected a 401 exception but got {str(context.exception)} instead" )
         notamFetch.credentials = good_credentials
 
     def test_bad_request( self ):
         with self.assertRaises( RuntimeError ) as context:
-            notamFetch.get_notams_at( self.COORDINATES, additional_params={"pageSize":999999} )
+            notamFetch.credentials = self.credentials
+            notamFetch.get_notams_at( self.COORDINATES, message_log=self.message_log, additional_params={"pageSize":999999} )
 
         self.assertTrue( "Received error message" in str(context.exception), f"Expected an error message but got {str(context.exception)} instead" )
 
     def test_not_found( self ):
         good_url = notamFetch.faa_api
         with self.assertRaises( RuntimeError ) as context:
+            notamFetch.credentials = self.credentials
             notamFetch.faa_api = f"{good_url}_OBVIOUSLY_BAD_URL"
-            notamFetch.get_notams_at( self.COORDINATES )
+            notamFetch.get_notams_at( self.COORDINATES, self.message_log )
 
         self.assertTrue( "HTTP 404" in str(context.exception), f"Expected a 404 exception but got {str(context.exception)} instead" )
         notamFetch.faa_api = good_url

--- a/tests/notamTests.py
+++ b/tests/notamTests.py
@@ -1,8 +1,11 @@
 import unittest
 import notamFetch
 from NavigationTools import *
+from io import StringIO
 
 class TestNotams(unittest.TestCase) :
+
+    message_log = StringIO()
 
     ## Tests involving user input:
 
@@ -12,14 +15,14 @@ class TestNotams(unittest.TestCase) :
     def test_inputs_valid_IATA(self):
         airport = "OKC"
         print("Testing IATA airport code input:")
-        self.assertTrue(notamFetch.is_valid_US_airport_code(airport), 
+        self.assertTrue(notamFetch.is_valid_US_airport_code(airport, self.message_log), 
                             f"{airport} was not detected as valid.")
           
     # Checks to see if ICAO codes are valid inputs.  
     def test_inputs_valid_ICAO(self):
         airport = "KOKC"
         print("Testing ICAO airport code input:")
-        self.assertTrue(notamFetch.is_valid_US_airport_code(airport), 
+        self.assertTrue(notamFetch.is_valid_US_airport_code(airport, self.message_log), 
                             f"{airport} was not detected as valid.")
         
     ## Tests involving invalid inputs in the frontend
@@ -29,34 +32,34 @@ class TestNotams(unittest.TestCase) :
         airport = None
         print("Testing no inputs:")
         with self.assertRaises(ValueError):
-            notamFetch.get_notams_at(airport)
+            notamFetch.get_notams_at(airport, self.message_log)
             
     # Test should fail given a code with too few characters.
     def test_inputs_invalid_few_char(self):
         airport = "OK"
         print("Testing inputs fewer than 3:")
-        self.assertFalse(notamFetch.is_valid_US_airport_code(airport, 
-                                f"{airport} was detected as valid."))
+        self.assertFalse(notamFetch.is_valid_US_airport_code(airport, self.message_log), 
+                                f"{airport} was detected as valid.")
         
     # Test should fail given a code with too many characters.
     def test_inputs_invalid_many_char(self):
         airport = "OKCDFW"
         print("Testing inputs greater than 4:")
-        self.assertFalse(notamFetch.is_valid_US_airport_code(airport, 
-                            f"{airport} was detected as valid."))
+        self.assertFalse(notamFetch.is_valid_US_airport_code(airport, self.message_log), 
+                            f"{airport} was detected as valid.")
         
     # Test other non-string inputs such as int and double:
     def test_inputs_invalid_int(self):
         airport = 46
         print("Testing integer inputs:")
         with self.assertRaises(ValueError):
-            notamFetch.get_notams_at(airport)
+            notamFetch.get_notams_at(airport, self.message_log)
 
     def test_inputs_invalid_float(self):
         airport = 35.3955
         print("Testing float decimal inputs:")
         with self.assertRaises(ValueError):
-            notamFetch.get_notams_at(airport)
+            notamFetch.get_notams_at(airport, self.message_log)
 
     ## Tests involving invalid airport inputs:
             
@@ -66,58 +69,57 @@ class TestNotams(unittest.TestCase) :
         airport = "PAJN" # Juneau, AK
         print(f"Testing {airport}:")
         with self.assertRaises(Exception):
-            notamFetch.get_notams_at(airport)
+            notamFetch.get_notams_at(airport, self.message_log)
 
     def test_hawaii_fail(self) :
         airport = "PHNL" # Honolulu, HI
         print(f"Testing {airport}:")
         with self.assertRaises(Exception):
-            notamFetch.get_notams_at(airport)
+            notamFetch.get_notams_at(airport, self.message_log)
 
     # Check airports in North America (i.e. Canada, Mexico, etc.)
             
     def test_canada(self):
         airport = "CYOW" # Ottawa, Canada
         print(f"Testing {airport}:")
-        self.assertFalse(notamFetch.is_valid_US_airport_code(airport, 
-                            f"{airport} was detected as a valid US airport."))
+        self.assertFalse(notamFetch.is_valid_US_airport_code(airport, self.message_log), 
+                            f"{airport} was detected as a valid US airport.")
             
     def test_mexico(self):
         airport = "MMMX" # Mexico City, Mexico
         print(f"Testing {airport}:")
-        self.assertFalse(notamFetch.is_valid_US_airport_code(airport, 
-                            f"{airport} was detected as a valid US airport."))
+        self.assertFalse(notamFetch.is_valid_US_airport_code(airport, self.message_log), 
+                            f"{airport} was detected as a valid US airport.")
 
     # Check airports outside North America
 
     def test_germany_fail(self):
         airport = "EDDB" # Berlin, Germany
         print(f"Testing {airport}:")
-        self.assertFalse(notamFetch.is_valid_US_airport_code(airport, 
-                            f"{airport} was detected as a valid US airport."))
+        self.assertFalse(notamFetch.is_valid_US_airport_code(airport, self.message_log), 
+                            f"{airport} was detected as a valid US airport.")
 
     ## Tests getting all notams with valid airports:
 
     # Check two close airports in the continental US
     
-    @unittest.skip("get_all_notams takes awhile to run as of now.")
     def test_close(self) :
         arrival_airport = "KMCI" # Kansas City, MO
         departure_airport = "KOKC" # Oklahoma City, OK
         print(f"Testing flight between {departure_airport} and {arrival_airport}:")
         try:
-            notamFetch.get_all_notams(departure_airport, arrival_airport)
+            notamFetch.get_all_notams(departure_airport, arrival_airport, self.message_log)
         except ValueError as err:
             self.fail("Airport was flagged as being the wrong type when checked.")
 
     # Check two far airports in the continental US
     
-    @unittest.skip("get_all_notams takes awhile to run as of now.")
+    @unittest.skip("Currently this path is too far for the program to handle")
     def test_far(self) :
         arrival_airport = "KPWM" # Portland, ME
         departure_airport = "KLAX" # Los Angeles, CA
         print(f"Testing flight between {departure_airport} and {arrival_airport}:")
         try:
-            notamFetch.get_all_notams(departure_airport, arrival_airport)
+            notamFetch.get_all_notams(departure_airport, arrival_airport, self.message_log)
         except ValueError as err:
             self.fail("Airport was flagged as being the wrong type when checked.")


### PR DESCRIPTION
Added and modified functions to allow for simultaneous FAA API calls. Currently, the code makes as many threads are there are requests, up to 50 (as 50 is our request limit per minute). If the number of requests are greater than 50, the program does not allow the request to go through to lessen traffic on the API.

However, since the request limit is 50, our current parameters cannot allow for all flight paths, as some may take more than 50 requests to handle. We should consider making our request area bigger and make our spacing further apart proportionally to the request area to handle any flight path in the US.