### PR TITLE
[KAN-60] Failed API calls now repeat several times when a failure is detected, if the fail is caused by hitting the API limit we wait

### DIFF
--- a/NotamFetch.py
+++ b/NotamFetch.py
@@ -106,10 +106,8 @@ def get_notams_at(request_location : PointObject, request_radius : int, message_
             raise RuntimeError( f"HTTP 404 return code from FAA API. Has the URL moved? Accessed url \"{FAA_API_ENTRYPOINT}\"" )
         if api_response.status_code == 429:
             return api_response.status_code
-            raise RuntimeError( f"HTTP 429 return code from FAA API. Your request limit has been reached, please wait 1 minute and try again." )
         if api_response.status_code != 200:
             return api_response.status_code
-            raise RuntimeError( f"Received non-HTTP 200 status code {api_response.status_code} from FAA API" )
 
         api_response_json = json.loads(api_response.text)
 


### PR DESCRIPTION
When we detect response code 429 from hitting the API usage limit we wait 60 seconds, if its a code other than 429 we don't wait and just retry it immediately.
I wasn't able to test response codes other than 429 and the repeated threads seem to run serially now but I'm not sure why.